### PR TITLE
Allow to use layout builder inside the call of layoutManager getLayout

### DIFF
--- a/src/Oro/Component/Layout/LayoutFactoryBuilder.php
+++ b/src/Oro/Component/Layout/LayoutFactoryBuilder.php
@@ -167,7 +167,7 @@ class LayoutFactoryBuilder implements LayoutFactoryBuilderInterface
         // initialize extension manager
         $registry = new LayoutRegistry();
         foreach ($this->extensions as $extension) {
-            $registry->addExtension($extension);
+            $registry->addExtension(clone $extension);
         }
         if (!empty($this->types) || !empty($this->typeExtensions) || !empty($this->layoutUpdates)) {
             $registry->addExtension(


### PR DESCRIPTION
This PR allow to use layout builder twice to render any layout block inside the call of `$layoutManager->getLayout()` during rendering the main website page.

**Use case**
I want to create new CMS widget for landing page to allow user in UI reuse any layouts blocks on a landing page. For example, I'd created the CMS widget `layout_block_render` to display `featured_categories` block

**Actual result**
I got an error. It is happens, because the service `ThemeExtension` is caches the layout context. So the cached context is shared on the different layout builder instances

```
BlockViewNotFoundException: BlockView with id "featured_categories" is not found.
```

**STR**
Create the simple CMS widget to render layout

![Selection_999(514)](https://user-images.githubusercontent.com/21358010/66309450-510cfe80-e912-11e9-94de-f7b9c609c77c.png)

```php
<?php

class LayoutBlockRenderWidget implements WidgetInterface
{
    /**
     * @var LayoutManager
     */
    private $layoutManager;

    /**
     * @param LayoutManager $layoutManager
     */
    public function __construct(LayoutManager $layoutManager)
    {
        $this->layoutManager = $layoutManager;
    }

    /**
     * {@inheritdoc}
     */
    public function render(array $options = [])
    {
        $layoutContext = new LayoutContext();
        $layoutContext->set('route_name', 'oro_frontend_root');
//        $layoutContext->set('theme', 'default');

        $layoutBuilder = $this->layoutManager->getLayoutBuilder();
        $layoutBuilder->add('root', null, 'root');

        $layout = $layoutBuilder->getLayout($layoutContext, 'featured_categories');
        $html = $layout->render();

        return $html;
    }
}

```
